### PR TITLE
Replace AccessControl with immutable roles in P2PSwapRouter

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,8 +1,0 @@
-module.exports = {
-  //   workingDir: process.cwd(),
-  //   contractsDir: path.join(process.cwd(), "contracts"),
-  //   instrumentedDir: path.join(process.cwd(), "instrumented"),
-  //   client: client,
-  skipFiles: ["dependencies/", "mocks/"],
-  //   logger: console,
-};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ contracts/
 
 ## Gotchas
 - **Coverage requires mkdir workaround** for `coverage/html/contracts/mocks` before running
+- **Hardhat 3 has no way to exclude files from coverage** — `.solcover.js` `skipFiles` is ignored (solidity-coverage plugin is not used). All compiled contracts appear in the report including mocks and dependencies. Track hardhat#7788 for a fix.
 - **Fork tests need Alchemy RPC URLs** — check `.env` for format, CI uses secrets
 - **USDM is a rebasing token** — fork tests allow off-by-one balance differences for USDM
 - **ESLint is strict** — many rules enabled that differ from defaults (no var, prefer template, sort imports/vars, etc.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md — swap-library
+
+## Repo overview
+- **What**: Solidity library for token swaps with a homogeneous interface. Supports Uniswap V3 and Curve Router.
+- **Published npm package**: `@ensuro/swaplibrary` (Apache-2.0)
+- **Org**: Ensuro — security contact: security@ensuro.co
+
+## Developer environment
+- **Node**: v22 (see `.nvmrc`). Use `nvm use` before anything else.
+- **Package manager**: npm. Run `npm ci` to install.
+- **Solidity**: 0.8.30, optimizer enabled (200 runs), EVM version `prague`.
+
+## Commands
+
+| Purpose | Command |
+|---|---|
+| Install deps | `npm ci` |
+| Compile | `npx hardhat compile` |
+| Run all tests | `npx hardhat test` |
+| Run tests with gas report | `REPORT_GAS=1 npx hardhat test` |
+| Run coverage | `mkdir -p coverage/html/contracts/mocks && npx hardhat test --coverage` |
+| Lint Solidity | `npm run solhint` |
+| Format code | `npm run prettier` |
+| Build NPM package | `scripts/make-npm-package.sh <version> [target-dir]` |
+
+**CI order**: `compile -> contract-size list -> solhint -> test -> coverage`
+
+## Testing
+- **Framework**: Mocha + Chai via `@nomicfoundation/hardhat-toolbox-mocha-ethers`
+- **Unit tests**: `test/test-swap-library.js` — uses mock contracts in `contracts/mocks/`
+- **Fork tests**: `test/test-fork-swap-library.js` — Polygon mainnet fork at block `57500000`
+  - Requires env vars: `ALCHEMY_URL` and `ALCHEMY_URL_POLYGON`
+  - Tests live swaps against real Uniswap and Curve contracts
+- **Helper utilities**: `js/utils.js` exports `Protocols` enum, `buildUniswapConfig()`, `buildCurveConfig()`
+- **@ensuro/utils**: Provides `_A()` (6-decimal amounts), `_W()` (18-decimal amounts), `initCurrency()`, `initForkCurrency()`, and custom Chai plugins
+
+## Architecture
+```
+contracts/
+  SwapLibrary.sol       # Core library: exactInput, exactOutput
+  CurveRoutes.sol       # Curve route finding and validation
+  P2PSwapRouter.sol     # Peer-to-peer swap router
+  interfaces/           # Interface definitions
+  dependencies/         # External interfaces (ICurveRouter)
+  mocks/                # Test-only contracts (SwapTesterMock, SwapRouterMock, etc.)
+```
+- `SwapLibrary` is a **library**, not a standalone contract. It must be linked to a deploying contract (see `SwapTesterMock` for the pattern).
+- SwapConfig struct: `{ protocol, maxSlippage, customParams }` — `customParams` is protocol-specific encoded bytes.
+
+## NPM package
+- Built via `scripts/make-npm-package.sh` which:
+  1. Compiles with `COMPILE_MODE=production`
+  2. Archives contracts/, js/, README.md
+  3. Copies artifacts to build/
+- Publishes to `./build/npm-package/` — run `npm publish --access public` from there
+- Release tags: `latest` (default) or `beta` (for `-beta` versions)
+
+## Linting/formatting
+- **Solidity**: solhint + prettier-plugin-solidity (120 char line width)
+- **JavaScript**: ESLint (strict rules, see `.eslintrc.js`) + Prettier
+- **Pre-commit**: pre-commit hooks run trailing-whitespace, gitleaks, eslint
+
+## Gotchas
+- **Coverage requires mkdir workaround** for `coverage/html/contracts/mocks` before running
+- **Fork tests need Alchemy RPC URLs** — check `.env` for format, CI uses secrets
+- **USDM is a rebasing token** — fork tests allow off-by-one balance differences for USDM
+- **ESLint is strict** — many rules enabled that differ from defaults (no var, prefer template, sort imports/vars, etc.)
+- **package.json version** uses `%%VERSION%%` placeholder — replaced by build script

--- a/contracts/P2PSwapRouter.sol
+++ b/contracts/P2PSwapRouter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -13,43 +12,52 @@ import {ISwapRouterErrors} from "./interfaces/ISwapRouterErrors.sol";
  * @notice Contract following the interface of ISwapRouter that executes single swaps from authorized contracts
  *         at configured prices, on behalf of an account
  */
-contract P2PSwapRouter is ISwapRouterErrors, AccessControl {
+contract P2PSwapRouter is ISwapRouterErrors {
   using SafeERC20 for IERC20Metadata;
   using Math for uint256;
   using SafeCast for uint256;
 
   uint256 internal constant WAD = 1e18;
-  bytes32 public constant SWAP_ROLE = keccak256("SWAP_ROLE");
-  bytes32 public constant PRICER_ROLE = keccak256("PRICER_ROLE");
-  bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+
+  struct Price {
+    address tokenIn;
+    address tokenOut;
+    uint256 price;
+  }
+
+  mapping(address tokenIn => mapping(address tokenOut => uint256 price)) internal _prices;
+  address public immutable onBehalfOf;
+  address public immutable swapper;
+  address public immutable pricer;
 
   event PriceUpdated(address tokenIn, address tokenOut, uint256 price);
-  event OnBehalfOfChanged(address indexed onBehalfOf);
+  error OnlySwapperCanSwap(address caller);
+  error OnlyPricerCanChangePrice(address caller);
 
-  mapping(address => mapping(address => uint256)) private _prices;
-  address internal _onBehalfOf;
-
-  constructor(address onBehalfOf, address admin) {
-    _grantRole(DEFAULT_ADMIN_ROLE, admin);
-    _setOnBehalfOf(onBehalfOf);
-  }
-
-  function _setOnBehalfOf(address onBehalfOf) internal {
-    _onBehalfOf = onBehalfOf;
-    emit OnBehalfOfChanged(onBehalfOf);
-  }
-
-  function getOnBehalfOf() external view returns (address) {
-    return _onBehalfOf;
+  constructor(address onBehalfOf_, address swapper_, address pricer_, Price[] memory initialPrices) {
+    swapper = swapper_;
+    pricer = pricer_;
+    onBehalfOf = onBehalfOf_;
+    for (uint256 i; i < initialPrices.length; ++i) {
+      Price memory p = initialPrices[i];
+      _setCurrentPrice(p.tokenIn, p.tokenOut, p.price);
+    }
   }
 
   function _toWadFactor(address token) internal view returns (uint256) {
     return (10 ** (18 - IERC20Metadata(token).decimals()));
   }
 
-  function exactInputSingle(
-    ExactInputSingleParams calldata params
-  ) external payable onlyRole(SWAP_ROLE) returns (uint256 amountOut) {
+  function _checkCallerIsSwapper() internal view {
+    require(msg.sender == swapper, OnlySwapperCanSwap(msg.sender));
+  }
+
+  function _checkCallerIsPricer() internal view {
+    require(msg.sender == pricer, OnlyPricerCanChangePrice(msg.sender));
+  }
+
+  function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut) {
+    _checkCallerIsSwapper();
     require(params.recipient != address(0), RecipientCannotBeZero());
     require(params.deadline >= block.timestamp, DeadlineInThePast());
     require(params.amountIn > 0, AmountCannotBeZero());
@@ -61,13 +69,12 @@ contract P2PSwapRouter is ISwapRouterErrors, AccessControl {
     amountOut = amountOutInWad / _toWadFactor(params.tokenOut);
     require(amountOut >= params.amountOutMinimum, OutputAmountLessThanSlippage(amountOut, params.amountOutMinimum));
 
-    IERC20Metadata(params.tokenIn).safeTransferFrom(msg.sender, _onBehalfOf, params.amountIn);
-    IERC20Metadata(params.tokenOut).safeTransferFrom(_onBehalfOf, params.recipient, amountOut);
+    IERC20Metadata(params.tokenIn).safeTransferFrom(msg.sender, onBehalfOf, params.amountIn);
+    IERC20Metadata(params.tokenOut).safeTransferFrom(onBehalfOf, params.recipient, amountOut);
   }
 
-  function exactOutputSingle(
-    ExactOutputSingleParams calldata params
-  ) external payable onlyRole(SWAP_ROLE) returns (uint256 amountIn) {
+  function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn) {
+    _checkCallerIsSwapper();
     require(params.recipient != address(0), RecipientCannotBeZero());
     require(params.deadline >= block.timestamp, DeadlineInThePast());
     require(params.amountOut > 0, AmountCannotBeZero());
@@ -79,11 +86,16 @@ contract P2PSwapRouter is ISwapRouterErrors, AccessControl {
     amountIn = amountInWad / _toWadFactor(params.tokenIn);
     require(amountIn <= params.amountInMaximum, InputAmountExceedsSlippage(amountIn, params.amountInMaximum));
 
-    IERC20Metadata(params.tokenIn).safeTransferFrom(msg.sender, _onBehalfOf, amountIn);
-    IERC20Metadata(params.tokenOut).safeTransferFrom(_onBehalfOf, params.recipient, params.amountOut);
+    IERC20Metadata(params.tokenIn).safeTransferFrom(msg.sender, onBehalfOf, amountIn);
+    IERC20Metadata(params.tokenOut).safeTransferFrom(onBehalfOf, params.recipient, params.amountOut);
   }
 
-  function setCurrentPrice(address tokenIn, address tokenOut, uint256 price_) external onlyRole(PRICER_ROLE) {
+  function setCurrentPrice(address tokenIn, address tokenOut, uint256 price_) external {
+    _checkCallerIsPricer();
+    _setCurrentPrice(tokenIn, tokenOut, price_);
+  }
+
+  function _setCurrentPrice(address tokenIn, address tokenOut, uint256 price_) internal {
     require(tokenIn != address(0), TokenCannotBeZero());
     require(tokenOut != address(0), TokenCannotBeZero());
     _prices[tokenIn][tokenOut] = price_;
@@ -92,10 +104,6 @@ contract P2PSwapRouter is ISwapRouterErrors, AccessControl {
 
   function getCurrentPrice(address tokenIn, address tokenOut) external view returns (uint256) {
     return _prices[tokenIn][tokenOut];
-  }
-
-  function setOnBehalfOf(address onBehalfOf) external onlyRole(ADMIN_ROLE) {
-    _setOnBehalfOf(onBehalfOf);
   }
 
   function exactOutput(ExactOutputParams calldata) external payable returns (uint256) {

--- a/contracts/P2PSwapRouter.sol
+++ b/contracts/P2PSwapRouter.sol
@@ -30,7 +30,7 @@ contract P2PSwapRouter is ISwapRouterErrors {
   address public immutable swapper;
   address public immutable pricer;
 
-  event PriceUpdated(address tokenIn, address tokenOut, uint256 price);
+  event PriceUpdated(address indexed tokenIn, address indexed tokenOut, uint256 price);
   error OnlySwapperCanSwap(address caller);
   error OnlyPricerCanChangePrice(address caller);
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     },
     npmFilesToBuild: ["@openzeppelin/contracts/token/ERC20/IERC20.sol"],
   },
+  // This is ignored as of HH 3.1.5, but I leave it here for future reference
+  coverage: {
+    skipFiles: ["contracts/mocks/", "contracts/dependencies/"],
+  },
   contractSizer: {
     alphaSort: true,
     runOnCompile: false,

--- a/test/test-fork-swap-library.js
+++ b/test/test-fork-swap-library.js
@@ -186,7 +186,7 @@ const variants = [
     tagit: tagit,
     fixture: async () => {
       const ret = await setUp();
-      const { lp, swapTesterMock, currency } = ret;
+      const { lp, admin, swapTesterMock, currency } = ret;
       const usdcNative = await initForkCurrency(
         connection,
         ADDRESSES.USDC_NATIVE,
@@ -196,10 +196,10 @@ const variants = [
       );
 
       const P2PSwapRouter = await ethers.getContractFactory("P2PSwapRouter");
-      const swapRouter = await P2PSwapRouter.deploy(swapTesterMock, swapTesterMock, lp, []);
-
-      await swapRouter.connect(lp).setCurrentPrice(ADDRESSES.USDC, ADDRESSES.USDC_NATIVE, _W("1"));
-      await swapRouter.connect(lp).setCurrentPrice(ADDRESSES.USDC_NATIVE, ADDRESSES.USDC, _W("1"));
+      const swapRouter = await P2PSwapRouter.deploy(lp, swapTesterMock, admin, [
+        { tokenIn: ADDRESSES.USDC, tokenOut: ADDRESSES.USDC_NATIVE, price: _W(1) },
+        { tokenIn: ADDRESSES.USDC_NATIVE, tokenOut: ADDRESSES.USDC, price: _W(1) },
+      ]);
 
       await currency.connect(lp).approve(swapRouter, _A(1000));
       await usdcNative.connect(lp).approve(swapRouter, _A(10000));

--- a/test/test-fork-swap-library.js
+++ b/test/test-fork-swap-library.js
@@ -186,7 +186,7 @@ const variants = [
     tagit: tagit,
     fixture: async () => {
       const ret = await setUp();
-      const { lp, admin, swapTesterMock, currency } = ret;
+      const { lp, swapTesterMock, currency } = ret;
       const usdcNative = await initForkCurrency(
         connection,
         ADDRESSES.USDC_NATIVE,
@@ -196,13 +196,7 @@ const variants = [
       );
 
       const P2PSwapRouter = await ethers.getContractFactory("P2PSwapRouter");
-      const swapRouter = await P2PSwapRouter.deploy(lp, admin);
-
-      const PRICER_ROLE = await swapRouter.PRICER_ROLE();
-      await swapRouter.connect(admin).grantRole(PRICER_ROLE, lp);
-
-      const SWAP_ROLE = await swapRouter.SWAP_ROLE();
-      await swapRouter.connect(admin).grantRole(SWAP_ROLE, swapTesterMock);
+      const swapRouter = await P2PSwapRouter.deploy(swapTesterMock, swapTesterMock, lp, []);
 
       await swapRouter.connect(lp).setCurrentPrice(ADDRESSES.USDC, ADDRESSES.USDC_NATIVE, _W("1"));
       await swapRouter.connect(lp).setCurrentPrice(ADDRESSES.USDC_NATIVE, ADDRESSES.USDC, _W("1"));

--- a/test/test-p2p-swap-router.js
+++ b/test/test-p2p-swap-router.js
@@ -1,8 +1,8 @@
 import hre from "hardhat";
-import { Assertion, expect } from "chai";
+import { expect } from "chai";
 
 import { initCurrency } from "@ensuro/utils/js/test-utils";
-import { _A, _W, getRole, grantRole } from "@ensuro/utils/js/utils";
+import { _A, _W } from "@ensuro/utils/js/utils";
 
 const connection = await hre.network.connect();
 const { networkHelpers: helpers, ethers } = connection;
@@ -10,132 +10,128 @@ const { ZeroAddress } = ethers;
 
 describe("P2PSwapRouter Unit Tests", function () {
   async function deployFixture() {
-    const [, seller, admin, buyer] = await ethers.getSigners();
+    const [, onBehalfOf, pricer, swapper, anon] = await ethers.getSigners();
 
     const usdc = await initCurrency(
       ethers,
       { name: "Test USDC", symbol: "USDC", decimals: 6, initial_supply: _A(100000) },
-      [seller, buyer],
+      [onBehalfOf, swapper],
       [_A(1000), _A(2000)]
     );
 
     const usdcNative = await initCurrency(
       ethers,
       { name: "Test USDC_NATIVE", symbol: "USDC_NATIVE", decimals: 6, initial_supply: _A(100000) },
-      [seller, buyer],
+      [onBehalfOf, swapper],
       [_A(1000), _A(2000)]
     );
 
     const P2PSwapRouter = await ethers.getContractFactory("P2PSwapRouter");
-    const p2pSwapRouter = await P2PSwapRouter.deploy(seller, admin);
+    const p2pSwapRouter = await P2PSwapRouter.deploy(onBehalfOf, swapper, pricer, []);
 
-    await grantRole(hre, p2pSwapRouter.connect(admin), "ADMIN_ROLE", admin);
-    await grantRole(hre, p2pSwapRouter.connect(admin), "PRICER_ROLE", seller);
-    await grantRole(hre, p2pSwapRouter.connect(admin), "SWAP_ROLE", buyer);
+    await usdc.connect(onBehalfOf).approve(p2pSwapRouter, _A(1000));
+    await usdcNative.connect(onBehalfOf).approve(p2pSwapRouter, _A(1000));
 
-    await usdc.connect(seller).approve(p2pSwapRouter, _A(1000));
-    await usdcNative.connect(seller).approve(p2pSwapRouter, _A(1000));
-
-    return { usdc, usdcNative, p2pSwapRouter, seller, admin, buyer };
+    return { usdc, usdcNative, p2pSwapRouter, onBehalfOf, pricer, swapper, anon };
   }
 
   it("Should allow a successful swap with exactInputSingle", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdcNative, usdc, _W("1"));
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    const { usdc, usdcNative, p2pSwapRouter, onBehalfOf, pricer, swapper } = await helpers.loadFixture(deployFixture);
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdcNative, usdc, _W("1"));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
-    await p2pSwapRouter.connect(buyer).exactInputSingle({
+    await p2pSwapRouter.connect(swapper).exactInputSingle({
       tokenIn: usdcNative,
       tokenOut: usdc,
       amountIn: _A(100),
       fee: 100,
-      recipient: buyer,
+      recipient: swapper,
       deadline: (await helpers.time.latest()) + 3600,
       amountOutMinimum: _A(95),
       sqrtPriceLimitX96: 0,
     });
 
-    const usdcBalanceAfter = await usdc.balanceOf(seller);
-    const usdcNativeBalanceAfter = await usdcNative.balanceOf(seller);
+    const usdcBalanceAfter = await usdc.balanceOf(onBehalfOf);
+    const usdcNativeBalanceAfter = await usdcNative.balanceOf(onBehalfOf);
 
     expect(usdcNativeBalanceAfter).to.equal(_A(1100));
     expect(usdcBalanceAfter).to.equal(_A(900));
   });
 
   it("Should allow a successful swap with exactOutputSingle", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, onBehalfOf, pricer, swapper } = await helpers.loadFixture(deployFixture);
 
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, _W("1"));
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, _W("1"));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(100));
 
-    await p2pSwapRouter.connect(buyer).exactOutputSingle({
+    await p2pSwapRouter.connect(swapper).exactOutputSingle({
       tokenIn: usdc,
       tokenOut: usdcNative,
       amountOut: _A(95),
       fee: 100,
-      recipient: buyer,
+      recipient: swapper,
       deadline: (await helpers.time.latest()) + 3600,
       amountInMaximum: _A(100),
       sqrtPriceLimitX96: 0,
     });
 
-    const usdcBalanceAfter = await usdc.balanceOf(seller);
-    const usdcNativeBalanceAfter = await usdcNative.balanceOf(seller);
+    const usdcBalanceAfter = await usdc.balanceOf(onBehalfOf);
+    const usdcNativeBalanceAfter = await usdcNative.balanceOf(onBehalfOf);
 
     expect(usdcBalanceAfter).to.equal(_A(1095));
     expect(usdcNativeBalanceAfter).to.equal(_A(905));
   });
 
-  it("exactInputSingle - Should revert if caller does not have SWAP_ROLE", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
+  it("exactInputSingle - Should revert if caller is not the swapper", async function () {
+    const { usdc, usdcNative, p2pSwapRouter, anon } = await helpers.loadFixture(deployFixture);
 
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdcNative.connect(anon).approve(p2pSwapRouter, _A(100));
 
     const deadline = (await helpers.time.latest()) + 3600;
 
     await expect(
-      p2pSwapRouter.connect(seller).exactInputSingle(
+      p2pSwapRouter.connect(anon).exactInputSingle(
         {
           tokenIn: usdcNative,
           tokenOut: usdc,
           amountIn: _A(100),
           fee: 100,
-          recipient: seller,
+          recipient: anon,
           deadline: deadline,
           amountOutMinimum: _A(95),
           sqrtPriceLimitX96: 0,
         },
         { gasLimit: 500000 }
       )
-    ).to.be.revertedWithACError(p2pSwapRouter, seller, "SWAP_ROLE");
+    ).to.be.revertedWithCustomError(p2pSwapRouter, "OnlySwapperCanSwap").withArgs(anon);
   });
 
-  it("exactOutputSingle - Should revert if caller does not have SWAP_ROLE", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
+  it("exactOutputSingle - Should revert if caller is not the swapper", async function () {
+    const { usdc, usdcNative, p2pSwapRouter, anon } = await helpers.loadFixture(deployFixture);
 
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdc.connect(anon).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(seller).exactOutputSingle({
+      p2pSwapRouter.connect(anon).exactOutputSingle({
         tokenIn: usdc,
         tokenOut: usdcNative,
         amountOut: _A(95),
         fee: 100,
-        recipient: seller,
+        recipient: anon,
         deadline: (await helpers.time.latest()) + 3600,
         amountInMaximum: _A(100),
         sqrtPriceLimitX96: 0,
       })
-    ).to.be.revertedWithACError(p2pSwapRouter, seller, "SWAP_ROLE");
+    ).to.be.revertedWithCustomError(p2pSwapRouter, "OnlySwapperCanSwap").withArgs(anon);
   });
 
   it("exactInputSingle - Should revert if recipient address is zero", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactInputSingle({
+      p2pSwapRouter.connect(swapper).exactInputSingle({
         tokenIn: usdcNative,
         tokenOut: usdc,
         amountIn: _A(100),
@@ -149,19 +145,19 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactInputSingle - Should revert if deadline is in the past", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     const deadline = (await helpers.time.latest()) - 3600 * 24;
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactInputSingle({
+      p2pSwapRouter.connect(swapper).exactInputSingle({
         tokenIn: usdcNative,
         tokenOut: usdc,
         amountIn: _A(100),
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: deadline,
         amountOutMinimum: _A(95),
         sqrtPriceLimitX96: 0,
@@ -170,17 +166,17 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactInputSingle - Should revert if amountIn is zero", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactInputSingle({
+      p2pSwapRouter.connect(swapper).exactInputSingle({
         tokenIn: usdcNative,
         tokenOut: usdc,
         amountIn: 0,
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: (await helpers.time.latest()) + 3600,
         amountOutMinimum: _A(95),
         sqrtPriceLimitX96: 0,
@@ -189,19 +185,19 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactInputSingle - Should revert if output amount is less than the slippage", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer, seller } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper, pricer } = await helpers.loadFixture(deployFixture);
 
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdcNative, usdc, _W("1"));
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdcNative, usdc, _W("1"));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactInputSingle({
+      p2pSwapRouter.connect(swapper).exactInputSingle({
         tokenIn: usdcNative,
         tokenOut: usdc,
         amountIn: _A(100),
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: (await helpers.time.latest()) + 3600,
         amountOutMinimum: _A(200),
         sqrtPriceLimitX96: 0,
@@ -212,12 +208,12 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactOutputSingle - Should revert if recipient address is zero", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactOutputSingle({
+      p2pSwapRouter.connect(swapper).exactOutputSingle({
         tokenIn: usdc,
         tokenOut: usdcNative,
         amountOut: _A(95),
@@ -231,19 +227,19 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactOutputSingle - Should revert if deadline is in the past", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     const deadline = (await helpers.time.latest()) - 3600;
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactOutputSingle({
+      p2pSwapRouter.connect(swapper).exactOutputSingle({
         tokenIn: usdc,
         tokenOut: usdcNative,
         amountOut: _A(95),
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: deadline,
         amountInMaximum: _A(100),
         sqrtPriceLimitX96: 0,
@@ -252,17 +248,17 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactOutputSingle - Should revert if amountOut is zero", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactOutputSingle({
+      p2pSwapRouter.connect(swapper).exactOutputSingle({
         tokenIn: usdc,
         tokenOut: usdcNative,
         amountOut: 0,
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: (await helpers.time.latest()) + 3600,
         amountInMaximum: _A(100),
         sqrtPriceLimitX96: 0,
@@ -271,19 +267,19 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("exactOutputSingle - Should revert if input amount exceeds slippage", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer, seller } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, swapper, pricer } = await helpers.loadFixture(deployFixture);
 
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(100));
 
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, _W("1"));
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, _W("1"));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactOutputSingle({
+      p2pSwapRouter.connect(swapper).exactOutputSingle({
         tokenIn: usdc,
         tokenOut: usdcNative,
         amountOut: _A(95),
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: Math.floor(Date.now() / 1000) + 3600,
         amountInMaximum: _A(50),
         sqrtPriceLimitX96: 0,
@@ -293,17 +289,15 @@ describe("P2PSwapRouter Unit Tests", function () {
       .withArgs(_A(95), _A(50));
   });
 
-  it("Should allow setting price when caller has PRICER_ROLE", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
+  it("Should allow setting price when caller is the pricer", async function () {
+    const { usdc, usdcNative, p2pSwapRouter, swapper, pricer } = await helpers.loadFixture(deployFixture);
     const newPrice = _W("1.5");
 
-    await expect(p2pSwapRouter.connect(buyer).setCurrentPrice(usdc, usdcNative, newPrice)).to.be.revertedWithACError(
-      p2pSwapRouter,
-      buyer,
-      "PRICER_ROLE"
-    );
+    await expect(p2pSwapRouter.connect(swapper).setCurrentPrice(usdc, usdcNative, newPrice))
+      .to.be.revertedWithCustomError(p2pSwapRouter, "OnlyPricerCanChangePrice")
+      .withArgs(swapper);
 
-    await expect(p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, newPrice))
+    await expect(p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, newPrice))
       .to.emit(p2pSwapRouter, "PriceUpdated")
       .withArgs(usdc, usdcNative, newPrice);
 
@@ -312,49 +306,47 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("Should revert if tokenOut or tokenIn is zero address", async function () {
-    const { usdc, p2pSwapRouter, seller } = await helpers.loadFixture(deployFixture);
+    const { usdc, p2pSwapRouter, pricer } = await helpers.loadFixture(deployFixture);
 
     await expect(
-      p2pSwapRouter.connect(seller).setCurrentPrice(usdc, ZeroAddress, _W("1"))
+      p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, ZeroAddress, _W("1"))
     ).to.be.revertedWithCustomError(p2pSwapRouter, "TokenCannotBeZero");
 
     await expect(
-      p2pSwapRouter.connect(seller).setCurrentPrice(ZeroAddress, usdc, _W("1"))
+      p2pSwapRouter.connect(pricer).setCurrentPrice(ZeroAddress, usdc, _W("1"))
     ).to.be.revertedWithCustomError(p2pSwapRouter, "TokenCannotBeZero");
   });
 
-  it("Should revert if caller does not have PRICER_ROLE", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+  it("Should revert if caller is not the pricer", async function () {
+    const { usdc, usdcNative, p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
     const newPrice = _W("2");
 
-    await expect(p2pSwapRouter.connect(buyer).setCurrentPrice(usdc, usdcNative, newPrice)).to.be.revertedWithACError(
-      p2pSwapRouter,
-      buyer,
-      "PRICER_ROLE"
-    );
+    await expect(p2pSwapRouter.connect(swapper).setCurrentPrice(usdc, usdcNative, newPrice))
+      .to.be.revertedWithCustomError(p2pSwapRouter, "OnlyPricerCanChangePrice")
+      .withArgs(swapper);
   });
 
   it("Should update price multiple times correctly", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, pricer } = await helpers.loadFixture(deployFixture);
     const firstPrice = _W("1.2");
     const secondPrice = _W("2.3");
 
-    await expect(p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, firstPrice))
+    await expect(p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, firstPrice))
       .to.emit(p2pSwapRouter, "PriceUpdated")
       .withArgs(usdc, usdcNative, firstPrice);
 
-    await expect(p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, secondPrice))
+    await expect(p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, secondPrice))
       .to.emit(p2pSwapRouter, "PriceUpdated")
       .withArgs(usdc, usdcNative, secondPrice);
   });
 
   it("Should revert when exactInput is called", async function () {
-    const { p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactInput({
+      p2pSwapRouter.connect(swapper).exactInput({
         amountIn: _A(100),
-        recipient: buyer,
+        recipient: swapper,
         deadline: Math.floor(Date.now() / 1000) + 3600,
         amountOutMinimum: _A(95),
         path: "0x",
@@ -363,12 +355,12 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("Should revert when exactOutput is called", async function () {
-    const { p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactOutput({
+      p2pSwapRouter.connect(swapper).exactOutput({
         amountOut: _A(95),
-        recipient: buyer,
+        recipient: swapper,
         deadline: Math.floor(Date.now() / 1000) + 3600,
         amountInMaximum: _A(100),
         path: "0x",
@@ -377,67 +369,46 @@ describe("P2PSwapRouter Unit Tests", function () {
   });
 
   it("Should revert when uniswapV3SwapCallback is called", async function () {
-    const { p2pSwapRouter, buyer } = await helpers.loadFixture(deployFixture);
+    const { p2pSwapRouter, swapper } = await helpers.loadFixture(deployFixture);
 
-    await expect(p2pSwapRouter.connect(buyer).uniswapV3SwapCallback(0, 0, "0x")).to.be.revertedWithCustomError(
+    await expect(p2pSwapRouter.connect(swapper).uniswapV3SwapCallback(0, 0, "0x")).to.be.revertedWithCustomError(
       p2pSwapRouter,
       "NotImplemented"
     );
   });
 
-  it("Should allow setting onBehalfOf when caller has ADMIN_ROLE", async function () {
-    const { p2pSwapRouter, admin, buyer } = await helpers.loadFixture(deployFixture);
-
-    await expect(p2pSwapRouter.connect(admin).setOnBehalfOf(buyer))
-      .to.emit(p2pSwapRouter, "OnBehalfOfChanged")
-      .withArgs(buyer);
-
-    const newOnBehalfOf = await p2pSwapRouter.getOnBehalfOf();
-    expect(newOnBehalfOf).to.equal(buyer.address);
-  });
-
-  it("Should revert if caller does not have ADMIN_ROLE", async function () {
-    const { p2pSwapRouter, buyer, seller } = await helpers.loadFixture(deployFixture);
-
-    await expect(p2pSwapRouter.connect(seller).setOnBehalfOf(buyer)).to.be.revertedWithACError(
-      p2pSwapRouter,
-      seller,
-      "ADMIN_ROLE"
-    );
-  });
-
   it("Successful input swaps with != 1 price & Slippage error", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdcNative, usdc, _W("1.02"));
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    const { usdc, usdcNative, p2pSwapRouter, onBehalfOf, pricer, swapper } = await helpers.loadFixture(deployFixture);
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdcNative, usdc, _W("1.02"));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
-    await p2pSwapRouter.connect(buyer).exactInputSingle({
+    await p2pSwapRouter.connect(swapper).exactInputSingle({
       tokenIn: usdcNative,
       tokenOut: usdc,
       amountIn: _A(100),
       fee: 100,
-      recipient: buyer,
+      recipient: swapper,
       deadline: Math.floor(Date.now() / 1000) + 3600,
       amountOutMinimum: _A(95),
       sqrtPriceLimitX96: 0,
     });
 
-    let usdcBalanceAfter = await usdc.balanceOf(seller);
-    let usdcNativeBalanceAfter = await usdcNative.balanceOf(seller);
+    let usdcBalanceAfter = await usdc.balanceOf(onBehalfOf);
+    let usdcNativeBalanceAfter = await usdcNative.balanceOf(onBehalfOf);
 
     expect(usdcNativeBalanceAfter).to.equal(_A(1100));
     expect(usdcBalanceAfter).to.be.closeTo(_A(900), _W("1.02"));
 
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdcNative, usdc, _W("1.06"));
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdcNative, usdc, _W("1.06"));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactInputSingle({
+      p2pSwapRouter.connect(swapper).exactInputSingle({
         tokenIn: usdcNative,
         tokenOut: usdc,
         amountIn: _A(100),
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: Math.floor(Date.now() / 1000) + 3600,
         amountOutMinimum: _A(95),
         sqrtPriceLimitX96: 0,
@@ -446,59 +417,59 @@ describe("P2PSwapRouter Unit Tests", function () {
       .to.be.revertedWithCustomError(p2pSwapRouter, "OutputAmountLessThanSlippage")
       .withArgs(_A("94.339622"), _A(95));
 
-    await p2pSwapRouter.connect(buyer).exactInputSingle({
+    await p2pSwapRouter.connect(swapper).exactInputSingle({
       tokenIn: usdcNative,
       tokenOut: usdc,
       amountIn: _A(100),
       fee: 100,
-      recipient: buyer,
+      recipient: swapper,
       deadline: Math.floor(Date.now() / 1000) + 3600,
       amountOutMinimum: _A(94),
       sqrtPriceLimitX96: 0,
     });
 
-    usdcBalanceAfter = await usdc.balanceOf(seller);
-    usdcNativeBalanceAfter = await usdcNative.balanceOf(seller);
+    usdcBalanceAfter = await usdc.balanceOf(onBehalfOf);
+    usdcNativeBalanceAfter = await usdcNative.balanceOf(onBehalfOf);
 
     expect(usdcNativeBalanceAfter).to.equal(_A(1200));
     expect(usdcBalanceAfter).to.be.closeTo(_A(800), _W("1.06"));
   });
 
   it("Successful output swaps with != 1 price & Slippage error", async function () {
-    const { usdc, usdcNative, p2pSwapRouter, seller, buyer } = await helpers.loadFixture(deployFixture);
+    const { usdc, usdcNative, p2pSwapRouter, onBehalfOf, pricer, swapper } = await helpers.loadFixture(deployFixture);
 
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, _W("0.98"));
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(105));
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, _W("0.98"));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(105));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
-    await p2pSwapRouter.connect(buyer).exactOutputSingle({
+    await p2pSwapRouter.connect(swapper).exactOutputSingle({
       tokenIn: usdc,
       tokenOut: usdcNative,
       amountOut: _A(100),
       fee: 100,
-      recipient: buyer,
+      recipient: swapper,
       deadline: Math.floor(Date.now() / 1000) + 3600,
       amountInMaximum: _A(102),
       sqrtPriceLimitX96: 0,
     });
 
-    let usdcBalanceAfter = await usdc.balanceOf(seller);
-    let usdcNativeBalanceAfter = await usdcNative.balanceOf(seller);
+    let usdcBalanceAfter = await usdc.balanceOf(onBehalfOf);
+    let usdcNativeBalanceAfter = await usdcNative.balanceOf(onBehalfOf);
 
     expect(usdcBalanceAfter).to.be.closeTo(_A(1100), _W("0.98"));
     expect(usdcNativeBalanceAfter).to.be.equal(_A(900));
 
-    await p2pSwapRouter.connect(seller).setCurrentPrice(usdc, usdcNative, _W("0.94"));
-    await usdc.connect(buyer).approve(p2pSwapRouter, _A(105));
-    await usdcNative.connect(buyer).approve(p2pSwapRouter, _A(100));
+    await p2pSwapRouter.connect(pricer).setCurrentPrice(usdc, usdcNative, _W("0.94"));
+    await usdc.connect(swapper).approve(p2pSwapRouter, _A(105));
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
 
     await expect(
-      p2pSwapRouter.connect(buyer).exactOutputSingle({
+      p2pSwapRouter.connect(swapper).exactOutputSingle({
         tokenIn: usdc,
         tokenOut: usdcNative,
         amountOut: _A(100),
         fee: 100,
-        recipient: buyer,
+        recipient: swapper,
         deadline: Math.floor(Date.now() / 1000) + 3600,
         amountInMaximum: _A(90),
         sqrtPriceLimitX96: 0,
@@ -507,21 +478,85 @@ describe("P2PSwapRouter Unit Tests", function () {
       .to.be.revertedWithCustomError(p2pSwapRouter, "InputAmountExceedsSlippage")
       .withArgs(_A(94), _A(90));
 
-    await p2pSwapRouter.connect(buyer).exactOutputSingle({
+    await p2pSwapRouter.connect(swapper).exactOutputSingle({
       tokenIn: usdc,
       tokenOut: usdcNative,
       amountOut: _A(100),
       fee: 100,
-      recipient: buyer,
+      recipient: swapper,
       deadline: Math.floor(Date.now() / 1000) + 3600,
       amountInMaximum: _A(105),
       sqrtPriceLimitX96: 0,
     });
 
-    usdcBalanceAfter = await usdc.balanceOf(seller);
-    usdcNativeBalanceAfter = await usdcNative.balanceOf(seller);
+    usdcBalanceAfter = await usdc.balanceOf(onBehalfOf);
+    usdcNativeBalanceAfter = await usdcNative.balanceOf(onBehalfOf);
 
     expect(usdcBalanceAfter).to.be.closeTo(_A(1200), _W("0.94"));
     expect(usdcNativeBalanceAfter).to.be.equal(_A(800));
+  });
+
+  it("Should allow setting prices in the constructor and swap successfully", async function () {
+    const { usdc, usdcNative, onBehalfOf, swapper, pricer } = await helpers.loadFixture(deployFixture);
+
+    const P2PSwapRouter = await ethers.getContractFactory("P2PSwapRouter");
+    const p2pSwapRouter = await P2PSwapRouter.deploy(onBehalfOf, swapper, pricer, [
+      { tokenIn: usdcNative, tokenOut: usdc, price: _W("1") },
+      { tokenIn: usdc, tokenOut: usdcNative, price: _W("1") },
+    ]);
+
+    await usdc.connect(onBehalfOf).approve(p2pSwapRouter, _A(1000));
+    await usdcNative.connect(onBehalfOf).approve(p2pSwapRouter, _A(1000));
+
+    await usdcNative.connect(swapper).approve(p2pSwapRouter, _A(100));
+
+    await p2pSwapRouter.connect(swapper).exactInputSingle({
+      tokenIn: usdcNative,
+      tokenOut: usdc,
+      amountIn: _A(100),
+      fee: 100,
+      recipient: swapper,
+      deadline: (await helpers.time.latest()) + 3600,
+      amountOutMinimum: _A(95),
+      sqrtPriceLimitX96: 0,
+    });
+
+    expect(await usdc.balanceOf(onBehalfOf)).to.equal(_A(900));
+    expect(await usdcNative.balanceOf(onBehalfOf)).to.equal(_A(1100));
+  });
+
+  it("Should have immutable prices when pricer is ZeroAddress", async function () {
+    const { usdc, usdcNative, onBehalfOf, swapper, anon } = await helpers.loadFixture(deployFixture);
+
+    const P2PSwapRouter = await ethers.getContractFactory("P2PSwapRouter");
+    const p2pSwapRouter = await P2PSwapRouter.deploy(onBehalfOf, swapper, ZeroAddress, [
+      { tokenIn: usdcNative, tokenOut: usdc, price: _W("1") },
+      { tokenIn: usdc, tokenOut: usdcNative, price: _W("1") },
+    ]);
+
+    await usdc.connect(onBehalfOf).approve(p2pSwapRouter, _A(1000));
+    await usdcNative.connect(onBehalfOf).approve(p2pSwapRouter, _A(1000));
+
+    expect(await p2pSwapRouter.getCurrentPrice(usdcNative, usdc)).to.equal(_W("1"));
+
+    await expect(
+      p2pSwapRouter.connect(anon).setCurrentPrice(usdcNative, usdc, _W("2"))
+    )
+      .to.be.revertedWithCustomError(p2pSwapRouter, "OnlyPricerCanChangePrice")
+      .withArgs(anon);
+
+    await expect(
+      p2pSwapRouter.connect(swapper).setCurrentPrice(usdcNative, usdc, _W("2"))
+    )
+      .to.be.revertedWithCustomError(p2pSwapRouter, "OnlyPricerCanChangePrice")
+      .withArgs(swapper);
+
+    await expect(
+      p2pSwapRouter.connect(onBehalfOf).setCurrentPrice(usdcNative, usdc, _W("2"))
+    )
+      .to.be.revertedWithCustomError(p2pSwapRouter, "OnlyPricerCanChangePrice")
+      .withArgs(onBehalfOf);
+
+    expect(await p2pSwapRouter.getCurrentPrice(usdcNative, usdc)).to.equal(_W("1"));
   });
 });


### PR DESCRIPTION
## Summary

- Removed AccessControl roles from P2PSwapRouter, replaced with immutable `swapper`, `pricer`, and `onBehalfOf` set at construction
- Added tests for constructor-set prices and ZeroAddress pricer (immutable prices pattern)
- Added AGENTS.md with high-signal guidance for OpenCode sessions